### PR TITLE
Don't install recommends

### DIFF
--- a/misc/40norecommends
+++ b/misc/40norecommends
@@ -1,0 +1,5 @@
+APT
+{
+        Install-Recommends "false";
+        Install-Suggests "false";
+};

--- a/misc/install.template
+++ b/misc/install.template
@@ -160,7 +160,6 @@ then
   sudo wget -q -O /etc/apt/apt.conf.d/50unattended-upgrades "https://raw.githubusercontent.com/flxn/tor-relay-configurator/master/misc/50unattended-upgrades.$DISTRO" && echoSuccess "-> wget OK" || handleError
   echoInfo "Don't install recommends..."
   sudo wget -q -O /etc/apt/apt.conf.d/40norecommends "https://raw.githubusercontent.com/flxn/tor-relay-configurator/master/misc/40norecommends" && echoSuccess "-> wget OK" || handleError
-
 fi
 
 sleep 10

--- a/misc/install.template
+++ b/misc/install.template
@@ -128,7 +128,7 @@ then
     disableIPV6
   else
     echoSuccess "Seems like your IPV6 connection is working"
-      
+
     IPV6_ADDRESS=$(ip -6 addr | grep inet6 | grep "scope global" | awk '{print $2}' | cut -d'/' -f1)
     if [ -z "$IPV6_ADDRESS" ]
     then
@@ -158,6 +158,9 @@ then
   sudo apt-get install -y unattended-upgrades apt-listchanges > /dev/null && echoSuccess "-> install OK" || handleError
   DISTRO=$(lsb_release -is)
   sudo wget -q -O /etc/apt/apt.conf.d/50unattended-upgrades "https://raw.githubusercontent.com/flxn/tor-relay-configurator/master/misc/50unattended-upgrades.$DISTRO" && echoSuccess "-> wget OK" || handleError
+  echoInfo "Don't install recommends..."
+  sudo wget -q -O /etc/apt/apt.conf.d/40norecommends "https://raw.githubusercontent.com/flxn/tor-relay-configurator/master/misc/40norecommends" && echoSuccess "-> wget OK" || handleError
+
 fi
 
 sleep 10


### PR DESCRIPTION
Hi,
when auto upgrades are enabled we should add the feature that Debian does not install the recommended packages, like [it's also done at torservers.net](https://torservers.net/wiki/setup/server#some_useful_defaults)