### PR TITLE
Pass Tor signing key directly from `curl` to `apt-key`, don’t use `gpg`

### DIFF
--- a/misc/install.template
+++ b/misc/install.template
@@ -61,8 +61,7 @@ echo "deb https://deb.torproject.org/torproject.org $RELEASE main" | sudo tee /e
 echo "deb-src https://deb.torproject.org/torproject.org $RELEASE main" | sudo tee --append /etc/apt/sources.list.d/tor.list > /dev/null && echoSuccess "-> tee2 OK" || handleError
 
 echoInfo "Adding Torproject GPG key..."
-curl https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --import > /dev/null && echoSuccess "-> gpg import OK" || handleError
-gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | sudo apt-key add - && echoSuccess "-> key-add OK" || handleError
+curl https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | sudo apt-key add - && echoSuccess "-> OK" || handleError
 
 echoInfo "Updating package list..."
 sudo apt-get -y update > /dev/null && echoSuccess "-> OK" || handleError


### PR DESCRIPTION
This commit makes the Tor signing key be directly piped to `apt-key`
from `curl`, removing the intermediate steps of importing it to,
then exporting it from, the user GPG pubkey ring.

Even if the Tor official doc also does it in two passes[1], there is,
as far as I can tell, no real need for these middle steps.
On the contrary, `gpg --import` has the side-effect of also putting
the Tor key into the calling user keyring. But that’s just polluting
the keyring; it’s dubious anything but `apt` will need the Tor package
signing key!

(From what concerns us here, note that there is no problem piping from
a “non-sudo `curl`” to a “sudo [`apt-key`]”, because the sudo password must
have been already entered by the user in a previous command.)

1: https://support.torproject.org/apt/